### PR TITLE
feature: modify page 구현

### DIFF
--- a/src/app/notice/[id]/modify/page.tsx
+++ b/src/app/notice/[id]/modify/page.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import axios from 'axios';
+
+import Button from '@/app/components/Button';
+import Editor from '@/app/components/Editor';
+
+import { Notice } from '@/types/notice';
+
+const Modify = ({
+  params: { id },
+}: {
+  params: { id: string };
+}): JSX.Element => {
+  const router = useRouter();
+
+  const [data, setData] = useState<Notice>({
+    id: '',
+    title: '',
+    date: '',
+    content: '',
+  });
+
+  const getNoticeList = async () => {
+    try {
+      const response = await axios.get(`http://localhost:9999/notice/${id}`);
+      setData(response.data);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const updateData = async () => {
+    try {
+      const response = await axios.patch(
+        `http://localhost:9999/notice/${id}`,
+        data
+      );
+
+      router.push(`http://localhost:3000/notice/${id}`);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setData({ ...data, [e.target.name]: e.target.value });
+  };
+
+  const handleQuillEdit = (value: string) => {
+    setData((prev) => {
+      return {
+        ...prev,
+        content: value,
+      };
+    });
+  };
+  const handleCancle = () => {
+    const result = window.confirm('작성하던 것을 취소하겠습니까?');
+    if (result) {
+      router.back();
+    }
+  };
+
+  const handleSubmit = () => {
+    updateData();
+  };
+
+  useEffect(() => {
+    getNoticeList();
+  }, []);
+
+  return (
+    <div className="notice-write-container">
+      <h2 className="notice-heading">공지사항</h2>
+      <div className="create-title">
+        <textarea
+          name="title"
+          placeholder="제목"
+          maxLength={100}
+          value={data.title}
+          onChange={handleChange}
+        ></textarea>
+      </div>
+      <div className="create-date">{/* <p>{date}</p> */}</div>
+      <Editor content={data.content} setContent={handleQuillEdit} />
+      <div className="button-box">
+        <Button
+          type="button"
+          disabled={false}
+          name="cancel"
+          content="취소"
+          onClick={handleCancle}
+        />
+        <Button
+          type="button"
+          disabled={false}
+          name="save"
+          content="저장"
+          onClick={handleSubmit}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Modify;


### PR DESCRIPTION
## 내용
- 해당 id 내용 가져와서 editor에 렌더링
- title, content 수정하여 data state에 저장
- 저장 버튼 누를시 axios patch에 data 전달
- 취소 버튼 누를시 이전 히스토리 스택으로 이동

### 할 일
- 수정 페이지 스타일
- 리팩토링
    - api 호출 함수 파일로 분리
    - Editor setContent type 수정
    - 공통적으로 사용하는 코드를 파일로 분리